### PR TITLE
Support for creating required belongs_to relationships

### DIFF
--- a/lib/HTML/FormFu/Model/DBIC.pm
+++ b/lib/HTML/FormFu/Model/DBIC.pm
@@ -369,11 +369,32 @@ sub update {
     my @rels = $rs->relationships;
     my @cols = $rs->columns;
 
+    # check for belongs_to relationships with a required foreign key
+    my (@mandatory_rels, @non_mandatory_rels);
+
+    foreach my $rel (@rels) {
+        # 'fk_columns' is set for belong_to rels in DBIx::Class::Relationship::BelongsTo
+        my @fk_columns = keys %{ $dbic->relationship_info($rel)->{attrs}{fk_columns} };
+
+        if ( @fk_columns and notall { $dbic->column_info($_)->{is_nullable} } @fk_columns ) {
+            push @mandatory_rels, $rel;
+        } else {
+            push @non_mandatory_rels, $rel;
+        }
+    }
+
+    # add required belongs_to rels before insert
+    if (@mandatory_rels) {
+        # tell _save_relationships not to update $dbic yet, just add the rels
+        my %attrs = ( %$attrs, no_update => 1 );
+        _save_relationships( $self, $base, $dbic, $form, $rs, \%attrs, \@mandatory_rels );
+    }
+
     _save_columns( $base, $dbic, $form ) or return;
 
     $dbic->update_or_insert;
 
-    _save_relationships( $self, $base, $dbic, $form, $rs, $attrs, \@rels );
+    _save_relationships( $self, $base, $dbic, $form, $rs, $attrs, \@non_mandatory_rels );
 
     _save_multi_value_fields_many_to_many( $base, $dbic, $form, $attrs, \@rels,
         \@cols );
@@ -462,7 +483,7 @@ sub _save_relationships {
                 } );
             unless ( $dbic->$rel ) {
                 $dbic->$rel($target);
-                $dbic->update;
+                $dbic->update unless $attrs->{no_update};
             }
         }
         elsif ( defined $multi_value ) {

--- a/t/lib/MySchema/ManagedBand.pm
+++ b/t/lib/MySchema/ManagedBand.pm
@@ -1,0 +1,26 @@
+package MySchema::ManagedBand;
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+__PACKAGE__->load_components(qw/ Core /);
+
+__PACKAGE__->table("managed_band");
+
+__PACKAGE__->add_columns(
+    id         => { data_type => "INTEGER", is_nullable => 0 },
+    manager_id => { data_type => "INTEGER", is_nullable => 0 },
+    band       => { data_type => "TEXT",    is_nullable => 0 },
+);
+
+__PACKAGE__->set_primary_key("id");
+
+__PACKAGE__->belongs_to( manager => 'MySchema::Manager', 'manager_id' );
+
+__PACKAGE__->has_many( user_bands => 'MySchema::UserBand', 'band' );
+
+__PACKAGE__->many_to_many( users => 'user_bands', 'user' );
+
+1;
+

--- a/t/update/belongs_to_create_required.t
+++ b/t/update/belongs_to_create_required.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+use HTML::FormFu;
+use lib 't/lib';
+use DBICTestLib 'new_schema';
+use MySchema;
+
+my $form = HTML::FormFu->new;
+
+$form->populate({
+    elements => [
+        {
+            name => 'band',
+        },
+        {
+            type => 'Block',
+            nested_name => 'manager',
+            elements => {
+                name => 'name',
+            }
+        }
+    ]
+});
+
+my $schema = new_schema();
+
+my $rs = $schema->resultset('ManagedBand');
+my $band = $rs->new_result({});
+
+$form->process({ band => 'The Foobars', 'manager.name' => 'Mr Foo' });
+
+$form->model('DBIC')->update($band);
+
+is($band->band, 'The Foobars');
+is($band->manager->name, 'Mr Foo');


### PR DESCRIPTION
Hi Carl,

Currently HTML::FormFu::Model::DBIC::update() will fail on creating a new row that has a ‘belongs_to’ relationship whose foreign key in the table is set to ‘NOT NULL’. The reason is that update() first adds all simple columns, inserts the new record into the database and only then proceeds to any relationships, i.e.:

```
_save_columns( ... );
$dbic->update_or_insert;
_save_relationships( ... );
```

If $dbic has a belongs_to relationship ‘manager’ with foreign key ‘manager_id’, and manager_id is required,   $dbic->update_or_insert will fail since manager_id is not populated until _save_relationships( ... ).

I have proposed a solution which identifies any such relationships and adds them to the new object before the first insert. All tests runs fine but I find the code in update() very difficult to follow and I am not sure if I have not introduced side effects which are not covered by the test suite.

Cheers,
## 

Peter
