### PR TITLE
read_only model config for checkboxgroup

### DIFF
--- a/lib/HTML/FormFu/Model/DBIC.pm
+++ b/lib/HTML/FormFu/Model/DBIC.pm
@@ -901,6 +901,8 @@ sub _save_multi_value_fields_many_to_many {
 
             my $config = $field->model_config;
 
+            next if $config->{read_only};
+
             my ($pk) = $config->{default_column}
                 || $related->result_source->primary_columns;
 

--- a/t/update/many_to_many_checkboxgroup.t
+++ b/t/update/many_to_many_checkboxgroup.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 5;
+use Test::More tests => 10;
 
 use HTML::FormFu;
 use lib 't/lib';
@@ -73,3 +73,34 @@ my $band1;
     is( $id[1], 3 );
 }
 
+{
+    $form->get_all_element({name => 'bands'})->model_config->{read_only} = 1;
+    $form->get_all_element({name => 'bands'})->model_config->{options_from_model} = 0;
+
+    $form->process( {
+            id    => 2,
+            name  => 'John Lennon',
+            bands => [ 2 ],
+        } );
+
+    ok( $form->submitted_and_valid );
+
+    my $row = $schema->resultset('User')->find(2);
+
+    $form->model->update($row);
+}
+
+{
+    my $row = $schema->resultset('User')->find(2);
+    
+    is( $row->name, 'John Lennon' );
+
+    my @bands = $row->bands->all;
+
+    is( scalar @bands, 2 );
+
+    my @id = sort map { $_->id } @bands;
+
+    is( $id[0], 1 );
+    is( $id[1], 3 );
+}


### PR DESCRIPTION
Hi,

After a wrong assumption and a dummy message in the mailing list on friday, we decided to add a check for model_config->{read_only} when saving checkboxgroup values.

An existing test file is expanded by the tests that show the success of the patch.

Would be great if you would apply the patch.
